### PR TITLE
Remove BKEX

### DIFF
--- a/mining-exchanges.md
+++ b/mining-exchanges.md
@@ -34,11 +34,6 @@
 [Kucoin](https://www.kucoin.com)
 - No KYC unless funds are more than 1 BTC
 - Withdrawel comming sooon!
-
-[Bkex](https://www.bkex.com/trade/GRIN_USDT)
-- KYC
-- Deposit-Withdrawal is supported (using memo system)
-- TOR Method ***
  
 [Bitforex](https://www.bitforex.com/en/spot/grin_usdt)
 - KYC


### PR DESCRIPTION
BKEX has suspended GRIN trading and withdrawals since 2022-03-25

Source: https://bkex.zendesk.com/hc/en-us/articles/5132847252633-BKEX-Has-Suspended-The-Trading-Function-Of-Some-Trading-Pairs

![image](https://user-images.githubusercontent.com/8020386/212820885-31d5a49a-bc7f-40cd-b128-279fb9132596.png)

![image](https://user-images.githubusercontent.com/8020386/212820867-0054b226-c9ab-401f-9588-889866014637.png)